### PR TITLE
Add feature: Prefix mentions of inactive users in issues and PRs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,9 @@ Object consisting of `logfile` and `log`. If `log` is set to true, then the merg
 
 Maps gitlab user names to github users. This is used to properly set assignees in issues and PRs and to translate mentions in issues.
 
+### inactiveUserSettings
+Takes a list of user names from GitLab, and the mentions of these users in issues and PRs will be prefixed with a `prepend` string when they are migrated to GitHub. This will be mostly used when migrating inactive users from GitLab to GitHub, ensuring that the inactive user names don't collide with existing GitHub users.
+
 ### projectmap
 
 This is useful when migrating multiple projects if they are renamed at destination. Provide a map from gitlab names to github names so that any cross-project references (e.g. issues) are not lost.

--- a/sample_settings.ts
+++ b/sample_settings.ts
@@ -27,6 +27,10 @@ export default {
     'username.gitlab.1': 'username.github.1',
     'username.gitlab.2': 'username.github.2',
   },
+  inactiveUserSettings: {
+    inactiveUserArray: [],
+    prepend: "👻"
+  },
   projectmap: {
     'gitlabgroup/projectname.1': 'GitHubOrg/projectname.1',
     'gitlabgroup/projectname.2': 'GitHubOrg/projectname.2',

--- a/src/githubHelper.ts
+++ b/src/githubHelper.ts
@@ -1148,6 +1148,9 @@ export class GithubHelper {
     const repoLink = `${this.githubUrl}/${this.githubOwner}/${this.githubRepo}`;
     const hasUsermap =
       settings.usermap !== null && Object.keys(settings.usermap).length > 0;
+    const hasInactiveUserSetting: boolean = 
+      settings.inactiveUserSettings?.inactiveUserArray !== null && 
+      settings.inactiveUserSettings?.inactiveUserArray?.length > 0;
     const hasProjectmap =
       settings.projectmap !== null &&
       Object.keys(settings.projectmap).length > 0;
@@ -1165,6 +1168,18 @@ export class GithubHelper {
         new RegExp(reString, 'g'),
         match => '@' + settings.usermap[match.substring(1)]
       );
+    }
+
+    //
+    // Inactive User mentions
+    //
+
+    if (hasInactiveUserSetting) {
+        let reString = `@(${settings.inactiveUserSettings?.inactiveUserArray.join('|')})`;
+        str = str.replace(
+            new RegExp(reString, 'g'),
+            match => `@${settings.inactiveUserSettings?.prepend}${match.substring(1)}`
+        );
     }
 
     //

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -5,6 +5,7 @@ export default interface Settings {
   usermap: {
     [key: string]: string;
   };
+  inactiveUserSettings?:InactiveUserSettings;
   projectmap: {
     [key: string]: string;
   };
@@ -60,4 +61,9 @@ export interface S3Settings {
   accessKeyId: string;
   secretAccessKey: string;
   bucket: string;
+}
+
+export interface InactiveUserSettings {
+    inactiveUserArray: string[];
+    prepend: string;
 }


### PR DESCRIPTION
Added Setting inactiveUserSettings.
It takes a list of user names from GitLab, and the mentions of these users in issues and PRs will be prefixed with a prepend string when they are migrated to GitHub. This will be mostly used when migrating inactive users from GitLab to GitHub, ensuring that the inactive user names don't collide with existing GitHub users.