### PR TITLE
Option to store attachments in Github repo.

### DIFF
--- a/sample_settings.ts
+++ b/sample_settings.ts
@@ -18,11 +18,15 @@ export default {
     repo: '{{repo}}',
     recreateRepo: false,
   },
-  s3: {
-    accessKeyId: '{{accessKeyId}}',
-    secretAccessKey: '{{secretAccessKey}}',
-    bucket: 'my-gitlab-bucket',
-  },
+//   s3: {
+//     accessKeyId: '{{accessKeyId}}',
+//     secretAccessKey: '{{secretAccessKey}}',
+//     bucket: 'my-gitlab-bucket',
+//   },
+githubAttachmentSettings: {
+    repo: '',
+    email: ''
+},
   usermap: {
     'username.gitlab.1': 'username.github.1',
     'username.gitlab.2': 'username.github.2',
@@ -61,4 +65,5 @@ export default {
     logFile: './merge-requests.json',
     log: false,
   },
+  
 } as Settings;

--- a/src/githubHelper.ts
+++ b/src/githubHelper.ts
@@ -1304,6 +1304,7 @@ export class GithubHelper {
 
     str = await utils.migrateAttachments(
       str,
+      this.githubApi,
       this.repoId,
       settings.s3,
       this.gitlabHelper

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -34,6 +34,7 @@ export default interface Settings {
     log: boolean;
   };
   s3?: S3Settings;
+  githubAttachmentSettings?: GithubAttachmentSettings;
 }
 
 export interface GithubSettings {
@@ -62,6 +63,11 @@ export interface S3Settings {
   secretAccessKey: string;
   bucket: string;
 }
+
+export interface GithubAttachmentSettings {
+    repo: string;
+    email: string;
+  }
 
 export interface InactiveUserSettings {
     inactiveUserMap: {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,12 @@
-import { S3Settings } from './settings';
+import { GithubAttachmentSettings, S3Settings } from './settings';
 import * as mime from 'mime-types';
 import * as path from 'path';
 import * as crypto from 'crypto';
 import S3 from 'aws-sdk/clients/s3';
 import { GitlabHelper } from './gitlabHelper';
+import { GithubSettings } from './settings';
+import settings from '../settings';
+import { Octokit as GitHubApi, RestEndpointMethodTypes } from '@octokit/rest';
 
 export const sleep = (milliseconds: number) => {
   return new Promise(resolve => setTimeout(resolve, milliseconds));
@@ -12,12 +15,12 @@ export const sleep = (milliseconds: number) => {
 // Creates new attachments and replaces old links
 export const migrateAttachments = async (
   body: string,
+  githubApi: GitHubApi,
   githubRepoId: number | undefined,
   s3: S3Settings | undefined,
   gitlabHelper: GitlabHelper
 ) => {
   const regexp = /(!?)\[([^\]]+)\]\((\/uploads[^)]+)\)/g;
-
   // Maps link offset to a new name in S3
   const offsetToAttachment: {
     [key: number]: string;
@@ -74,7 +77,53 @@ export const migrateAttachments = async (
       offsetToAttachment[
         match.index as number
       ] = `${prefix}[${name}](${s3url})`;
-    } else {
+    }
+    // Using Github attachmentRepo
+    else if (settings.githubAttachmentSettings?.repo){
+      const basename = path.basename(url);
+      const mimeType = mime.lookup(basename);
+      const attachmentBuffer = await gitlabHelper.getAttachment(url);
+      if (!attachmentBuffer) {
+        continue;
+      }
+      const b64Data = attachmentBuffer.toString('base64');
+
+      // // Generate file name for S3 bucket from URL
+      const hash = crypto.createHash('sha256');
+      const uuid_n = crypto.randomUUID();
+      hash.update(url);
+      const newFileName = hash.digest('hex') + `-${uuid_n}` + '/' + basename;
+      const relativePath = githubRepoId
+        ? `${githubRepoId}/${newFileName}`
+        : newFileName;
+      // Doesn't seem like it is easy to upload an issue to github, so upload to S3
+      //https://stackoverflow.com/questions/41581151/how-to-upload-an-image-to-use-in-issue-comments-via-github-api
+      let owner = settings.github.owner;
+      const final_url = `https://github.com/${owner}/${settings.githubAttachmentSettings.repo}/blob/main/${relativePath}`;
+        console.log(`\tUploading ${basename} to ${final_url}... `);
+        githubApi.request(`PUT /repos/${owner}/${settings.githubAttachmentSettings.repo}/contents/${relativePath}`, {
+            owner: owner,
+            repo: settings.githubAttachmentSettings.repo,
+            path: `${relativePath}`,
+            message: `${basename} commit`,
+            ref: 'heads/main',
+            committer: {
+              name: settings.github.token_owner,
+              email: settings.githubAttachmentSettings.email
+            },
+            content: b64Data,
+            headers: {
+              'X-GitHub-Api-Version': '2022-11-28'
+            }
+          }).catch(err => {
+            console.log(`Error while transfering ${relativePath}`);
+          })
+        // Add the new URL to the map
+      offsetToAttachment[
+        match.index as number
+      ] = `[📎${name}](${final_url})`;
+    }
+    else {
       // Not using S3: default to old URL, adding absolute path
       const host = gitlabHelper.host.endsWith('/')
         ? gitlabHelper.host


### PR DESCRIPTION
This feature will help to upload the attachments to a specified GitHub repo.
```ts
githubAttachmentSettings: {
    repo: 'attachment-repo-name',
    email: 'email-address-of-token-owner'
},
```
Each attachment is pushed to the attachment repo as a file in a commit. 
The link of the file is then added in place of attachments with a  📎[attachment-name](www.github.com/example/main/blob/somerandomlink)